### PR TITLE
libkrun: fix branch name in disable-display patch url

### DIFF
--- a/Formula/libkrun.rb
+++ b/Formula/libkrun.rb
@@ -12,7 +12,7 @@ class Libkrun < Formula
   end
 
   patch do
-    url "https://raw.githubusercontent.com/slp/homebrew-krun/refs/heads/drop-display/patches/libkrun-disable-display.diff"
+    url "https://raw.githubusercontent.com/slp/homebrew-krun/refs/heads/master/patches/libkrun-disable-display.diff"
     sha256 "3e11baec017c6dc7bc5c92731b7db19cd597f74c20b4e41497aaa82ea68bfa0e"
   end
 


### PR DESCRIPTION
## Context
After https://github.com/slp/homebrew-krun/pull/15 was merged, the `drop-display` branch was deleted, which seems to have broken the brew tap:
```
% brew install slp/krun/libkrun
==> Fetching downloads for: libkrun
==> Fetching slp/krun/libkrun
==> Downloading https://raw.githubusercontent.com/slp/homebrew-krun/refs/heads/drop-display/patches/libkrun-disa
curl: (56) The requested URL returned error: 404

Error: libkrun: Failed to download resource "libkrun-disable-display.diff"
Download failed: https://raw.githubusercontent.com/slp/homebrew-krun/refs/heads/drop-display/patches/libkrun-disable-display.diff
```

## Changes
Updated the URL for the patch in `Formula/libkrun.rb` to refer to the `master` branch

## Tests
1. Ran `brew edit` on this branch to update the formula locally
```
% EDITOR="cp ./Formula/libkrun.rb $1" brew edit slp/krun/libkrun
Editing /opt/homebrew/Library/Taps/slp/homebrew-krun/Formula/libkrun.rb
```
2. Observed installation succeeding
```
% brew install slp/krun/libkrun                                 
==> Fetching downloads for: libkrun
==> Fetching slp/krun/libkrun
==> Downloading https://raw.githubusercontent.com/slp/homebrew-krun/refs/heads/master/patches/libkrun-disable-display.diff
[...]
```
